### PR TITLE
Added line to lower nearClipPlane value.

### DIFF
--- a/src/HarmonyManager.cs
+++ b/src/HarmonyManager.cs
@@ -181,6 +181,9 @@ namespace Receiver2ModdingKit {
 				}
 			}
 
+			//doing this prevents stocks for some guns from clipping into the camera.
+			ReceiverCoreScript.Instance().player_prefab.GetComponent<PlayerScript>().main_camera_prefab.GetComponent<Camera>().nearClipPlane = 0.02f;
+
 			try {
 				ModdingKitConfig.Initialize();
 			} catch {


### PR DESCRIPTION
This way, guns like the MP9, or the M3S90, whose stocks are very long and very close to the camera, won't clip. And It'll only have to be done once, instead of manually added by the maker of the gunmod.